### PR TITLE
PSR-16 Cache Driver Support for TourCMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/config.php
 src/examples/config.php
 .idea
 vendor
+.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 config.php
 src/config.php
 src/examples/config.php
+.idea
+vendor

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ $cacheDriver = new SimpleCache($flysystem);
 
 $tourcms = new TourCMS(1, "YOUR_KEY", "simplexml", $cacheDriver);
 
-$tours = $tourcms->search_tours();
+$params = "lat=56.82127&long=-6.09139&k=walking";
+$channel = 3;
+$tours = $tourcms->search_tours($params, $channel);
 ```
 
 Then in another request or just later

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   * [Installing Manually](#installing-manually)
   * [Upgrading from v1.x](#upgrading-from-version-1x)
 * [Usage](#usage)
+* [Caching (PSR-16)](#caching-psr-16)
 * [Further examples](#further-examples)
 * [Environment test](#environment-test)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $filesystem = new Filesystem($adapter);
 $flysystem = new Flysystem($filesystem);
 $cacheDriver = new SimpleCache($flysystem);
 
-$tourcms = new TourCMS(1, "YOUR_KEY", "simplexml", $cacheDriver);
+$tourcms = new TourCMS(1, "YOUR_KEY", "simplexml", 0, $cacheDriver);
 
 $params = "lat=56.82127&long=-6.09139&k=walking";
 $channel = 3;
@@ -149,7 +149,7 @@ $config = TourCMS::$default_cache_timeouts;
 unset($config['show_supplier']);
 $config["show_tour"] = ["time" => 60 * 30];
 
-$tourcms = new TourCMS(1, "YOUR_KEY", "simplexml", $cacheDriver, $config);
+$tourcms = new TourCMS(1, "YOUR_KEY", "simplexml", 0, $cacheDriver, $config);
 
 ```  
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $tourcms = new TourCMS\Utils\TourCMS(0, 'YOUR_PASSWORD', 'simplexml');
 ```
 
 ## Caching (PSR-16)
-The TourCMS object can receive a PSR-16 SimpleCache object in its constructor as the fourth argument that is treated as the cache driver when set.
+The TourCMS object can receive a PSR-16 SimpleCache object in its constructor as the fifth argument that is treated as the cache driver when set.
 ### PSR-16
 [PSR-16](https://www.php-fig.org/psr/psr-16/) is a commonly used Interface for cache drivers. Most established cache libraries implement the interface or offer adapters.
 
@@ -134,7 +134,7 @@ The default configuration is stored in a static property `TourCMS::$default_cach
 This array contains the API methods with their timeout values that are recommended by TourCMS.
 
 If you wish to make changes to these default values simply take the above mentioned default array,
-adjust the values and provide the newly formed configuration array as a fifth argument to the constructor
+adjust the values and provide the newly formed configuration array as a sixth argument to the constructor
 of `TourCMS`
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "spatie/phpunit-watcher": "^1.22",
         "matthiasmullie/scrapbook": "^1.4",
         "league/flysystem": "^1.0",
-        "mockery/mockery": "^1.3"
+        "mockery/mockery": "^1.3",
+        "symfony/var-dumper": "^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "psr/simple-cache": "^1.0"
     },
     "autoload": {
         "psr-4": {"TourCMS\\Utils\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require-dev": {
         "spatie/phpunit-watcher": "^1.22",
         "matthiasmullie/scrapbook": "^1.4",
-        "league/flysystem": "^1.0"
+        "league/flysystem": "^1.0",
+        "mockery/mockery": "^1.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": ">=7.1",
         "psr/simple-cache": "^1.0",
-        "phpunit/phpunit": "^9.0",
         "ext-simplexml": "*"
     },
     "autoload": {
@@ -45,6 +44,7 @@
         "league/flysystem": "^1.0",
         "mockery/mockery": "^1.3",
         "symfony/var-dumper": "^5.0",
-        "ext-simplexml": "*"
+        "ext-simplexml": "*",
+        "phpunit/phpunit": "^9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=7.1",
         "psr/simple-cache": "^1.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0",
+        "ext-simplexml": "*"
     },
     "autoload": {
         "psr-4": {"TourCMS\\Utils\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         ]
     },
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.1",
         "psr/simple-cache": "^1.0",
         "phpunit/phpunit": "^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.5",
         "psr/simple-cache": "^1.0",
         "phpunit/phpunit": "^9.0"
     },
@@ -30,5 +30,8 @@
                 "dev-master": "3.2.x-dev",
                 "dev-v1.x": "1.9.x-dev"
             }
-        }
+        },
+    "require-dev": {
+        "phpfastcache/phpfastcache": "^8.0"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "matthiasmullie/scrapbook": "^1.4",
         "league/flysystem": "^1.0",
         "mockery/mockery": "^1.3",
-        "symfony/var-dumper": "^5.0"
+        "symfony/var-dumper": "^5.0",
+        "ext-simplexml": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,13 @@
             "homepage": "http://www.tourcms.com"
         }
     ],
+    "scripts": {
+        "test": "phpunit",
+        "test:watch": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit-watcher watch"
+        ]
+    },
     "require": {
         "php": ">=5.5",
         "psr/simple-cache": "^1.0",
@@ -32,6 +39,8 @@
             }
         },
     "require-dev": {
-        "phpfastcache/phpfastcache": "^8.0"
+        "spatie/phpunit-watcher": "^1.22",
+        "matthiasmullie/scrapbook": "^1.4",
+        "league/flysystem": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,16 @@
     ],
     "require": {
         "php": ">=5.3",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {"TourCMS\\Utils\\": "src/"}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     },
     "extra": {
             "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58cc084264479f1fb0d48c8c927aa691",
+    "content-hash": "a22e0c307f258ec90aa251818410cd88",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1851,6 +1851,54 @@
             "time": "2017-07-23T21:35:13+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20T08:20:44+00:00"
+        },
+        {
             "name": "jolicode/jolinotif",
             "version": "v2.1.0",
             "source": {
@@ -2077,6 +2125,71 @@
                 "value"
             ],
             "time": "2019-08-30T09:35:02+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2019-12-26T09:49:15+00:00"
         },
         {
             "name": "psr/cache",
@@ -2787,7 +2900,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=7.1"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a22e0c307f258ec90aa251818410cd88",
+    "content-hash": "20479feb899ebdec6d67a8fd4482528a",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -2780,6 +2780,81 @@
                 "standards"
             ],
             "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "f74a126acd701392eef2492a17228d42552c86b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f74a126acd701392eef2492a17228d42552c86b5",
+                "reference": "f74a126acd701392eef2492a17228d42552c86b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc8e1ca37f622f4652721ec7dc9a13d8",
+    "content-hash": "386c6aa214e3351352f1e779baed0682",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1636,7 +1636,157 @@
             "time": "2020-02-14T12:15:55+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpfastcache/phpfastcache",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPSocialNetwork/phpfastcache.git",
+                "reference": "7a55eedda16a53c1a97161354718e690e2b6067e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPSocialNetwork/phpfastcache/zipball/7a55eedda16a53c1a97161354718e690e2b6067e",
+                "reference": "7a55eedda16a53c1a97161354718e690e2b6067e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.3",
+                "psr/cache": "~1.0.0",
+                "psr/simple-cache": "~1.0.0"
+            },
+            "conflict": {
+                "basho/riak": "*",
+                "doctrine/couchdb": "*"
+            },
+            "require-dev": {
+                "league/climate": "^3.5"
+            },
+            "suggest": {
+                "ext-apc": "*",
+                "ext-couchbase": "*",
+                "ext-intl": "*",
+                "ext-leveldb": "*",
+                "ext-memcache": "*",
+                "ext-memcached": "*",
+                "ext-redis": "*",
+                "ext-sqlite": "*",
+                "ext-wincache": "*",
+                "ext-xcache": "*",
+                "mongodb/mongodb": "^1.1",
+                "phpfastcache/couchdb": "~1.0.0",
+                "phpfastcache/phpssdb": "~1.0.0",
+                "phpfastcache/riak-client": "~1.4.4",
+                "predis/predis": "~1.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phpfastcache\\": "lib/Phpfastcache/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Georges.L",
+                    "email": "contact@geolim4.com",
+                    "homepage": "https://github.com/Geolim4",
+                    "role": "Actual Project Manager/Developer"
+                },
+                {
+                    "name": "Khoa Bui",
+                    "email": "khoaofgod@gmail.com",
+                    "homepage": "https://www.phpfastcache.com",
+                    "role": "Former Project Developer/Original Creator"
+                }
+            ],
+            "description": "PHP Abstract Cache Class - Reduce your database call using cache system. PhpFastCache handles a lot of drivers such as Apc(u), Cassandra, CouchBase, Couchdb, Mongodb, Files, (P)redis, Leveldb, Memcache(d), Ssdb, Sqlite, Wincache, Xcache, Zend Data Cache.",
+            "homepage": "https://www.phpfastcache.com",
+            "keywords": [
+                "LevelDb",
+                "abstract",
+                "apc",
+                "apcu",
+                "cache",
+                "cache class",
+                "caching",
+                "cassandra",
+                "cookie",
+                "couchbase",
+                "couchdb",
+                "files cache",
+                "memcache",
+                "memcached",
+                "mongodb",
+                "mysql cache",
+                "pdo cache",
+                "php cache",
+                "predis",
+                "redis",
+                "ssdb",
+                "wincache",
+                "xcache",
+                "zend",
+                "zend data cache",
+                "zend disk cache",
+                "zend memory cache",
+                "zend server"
+            ],
+            "time": "2020-03-22T22:36:21+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "386c6aa214e3351352f1e779baed0682",
+    "content-hash": "58cc084264479f1fb0d48c8c927aa691",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1638,54 +1638,38 @@
     ],
     "packages-dev": [
         {
-            "name": "phpfastcache/phpfastcache",
-            "version": "8.0.0",
+            "name": "clue/stdio-react",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPSocialNetwork/phpfastcache.git",
-                "reference": "7a55eedda16a53c1a97161354718e690e2b6067e"
+                "url": "https://github.com/clue/reactphp-stdio.git",
+                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPSocialNetwork/phpfastcache/zipball/7a55eedda16a53c1a97161354718e690e2b6067e",
-                "reference": "7a55eedda16a53c1a97161354718e690e2b6067e",
+                "url": "https://api.github.com/repos/clue/reactphp-stdio/zipball/5f42a3a5a29f52432f0f68b57890353e8ca65069",
+                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": ">=7.3",
-                "psr/cache": "~1.0.0",
-                "psr/simple-cache": "~1.0.0"
-            },
-            "conflict": {
-                "basho/riak": "*",
-                "doctrine/couchdb": "*"
+                "clue/term-react": "^1.0 || ^0.1.1",
+                "clue/utf8-react": "^1.0 || ^0.1",
+                "php": ">=5.3",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+                "react/stream": "^1.0 || ^0.7 || ^0.6"
             },
             "require-dev": {
-                "league/climate": "^3.5"
+                "clue/arguments": "^2.0",
+                "clue/commander": "^1.2",
+                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
             },
             "suggest": {
-                "ext-apc": "*",
-                "ext-couchbase": "*",
-                "ext-intl": "*",
-                "ext-leveldb": "*",
-                "ext-memcache": "*",
-                "ext-memcached": "*",
-                "ext-redis": "*",
-                "ext-sqlite": "*",
-                "ext-wincache": "*",
-                "ext-xcache": "*",
-                "mongodb/mongodb": "^1.1",
-                "phpfastcache/couchdb": "~1.0.0",
-                "phpfastcache/phpssdb": "~1.0.0",
-                "phpfastcache/riak-client": "~1.4.4",
-                "predis/predis": "~1.1.0"
+                "ext-mbstring": "Using ext-mbstring should provide slightly better performance for handling I/O"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Phpfastcache\\": "lib/Phpfastcache/"
+                    "Clue\\React\\Stdio\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1694,51 +1678,405 @@
             ],
             "authors": [
                 {
-                    "name": "Georges.L",
-                    "email": "contact@geolim4.com",
-                    "homepage": "https://github.com/Geolim4",
-                    "role": "Actual Project Manager/Developer"
-                },
-                {
-                    "name": "Khoa Bui",
-                    "email": "khoaofgod@gmail.com",
-                    "homepage": "https://www.phpfastcache.com",
-                    "role": "Former Project Developer/Original Creator"
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
                 }
             ],
-            "description": "PHP Abstract Cache Class - Reduce your database call using cache system. PhpFastCache handles a lot of drivers such as Apc(u), Cassandra, CouchBase, Couchdb, Mongodb, Files, (P)redis, Leveldb, Memcache(d), Ssdb, Sqlite, Wincache, Xcache, Zend Data Cache.",
-            "homepage": "https://www.phpfastcache.com",
+            "description": "Async, event-driven console input & output (STDIN, STDOUT) for truly interactive CLI applications, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/reactphp-stdio",
             "keywords": [
-                "LevelDb",
-                "abstract",
-                "apc",
-                "apcu",
-                "cache",
-                "cache class",
-                "caching",
-                "cassandra",
-                "cookie",
-                "couchbase",
-                "couchdb",
-                "files cache",
-                "memcache",
-                "memcached",
-                "mongodb",
-                "mysql cache",
-                "pdo cache",
-                "php cache",
-                "predis",
-                "redis",
-                "ssdb",
-                "wincache",
-                "xcache",
-                "zend",
-                "zend data cache",
-                "zend disk cache",
-                "zend memory cache",
-                "zend server"
+                "async",
+                "autocomplete",
+                "autocompletion",
+                "cli",
+                "history",
+                "interactive",
+                "reactphp",
+                "readline",
+                "stdin",
+                "stdio",
+                "stdout"
             ],
-            "time": "2020-03-22T22:36:21+00:00"
+            "time": "2019-08-28T12:01:30+00:00"
+        },
+        {
+            "name": "clue/term-react",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-term.git",
+                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-term/zipball/3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
+                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.0 || ^0.7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Term\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Streaming terminal emulator, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/reactphp-term",
+            "keywords": [
+                "C0",
+                "CSI",
+                "ansi",
+                "apc",
+                "ascii",
+                "c1",
+                "control codes",
+                "dps",
+                "osc",
+                "pm",
+                "reactphp",
+                "streaming",
+                "terminal",
+                "vt100",
+                "xterm"
+            ],
+            "time": "2018-07-09T08:20:33+00:00"
+        },
+        {
+            "name": "clue/utf8-react",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-utf8-react.git",
+                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-utf8-react/zipball/c6111a22e1056627c119233ff5effe00f5d3cc1d",
+                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4 || ^0.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8",
+                "react/stream": "^1.0 || ^0.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Utf8\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Streaming UTF-8 parser, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/php-utf8-react",
+            "keywords": [
+                "reactphp",
+                "streaming",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "time": "2017-07-06T07:43:22+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
+                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Evenement": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "time": "2017-07-23T21:35:13+00:00"
+        },
+        {
+            "name": "jolicode/jolinotif",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jolicode/JoliNotif.git",
+                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/b1a7ccfeb13f1daa12a5188531863b739e388e13",
+                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "symfony/process": "^3.3|^4.0|^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "symfony/finder": "^3.3|^4.0|^5.0",
+                "symfony/phpunit-bridge": "^3.4.26|^4.0|^5.0"
+            },
+            "bin": [
+                "jolinotif"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joli\\JoliNotif\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïck Piera",
+                    "email": "pyrech@gmail.com"
+                }
+            ],
+            "description": "Send desktop notifications on Windows, Linux, MacOS.",
+            "keywords": [
+                "MAC",
+                "growl",
+                "linux",
+                "notification",
+                "windows"
+            ],
+            "time": "2020-01-10T15:37:00+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.66",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/021569195e15f8209b1c4bebb78bd66aa4f08c21",
+                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7.26"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2020-03-17T18:58:12+00:00"
+        },
+        {
+            "name": "matthiasmullie/scrapbook",
+            "version": "1.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matthiasmullie/scrapbook.git",
+                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matthiasmullie/scrapbook/zipball/d27ff1ab823f288918d3c593cd3c7e56db0e7745",
+                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0",
+                "psr/cache": "~1.0",
+                "psr/simple-cache": "~1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "~1.0",
+                "psr/simple-cache-implementation": "~1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.0",
+                "phpunit/phpunit": "~4.8|~5.0|~6.0"
+            },
+            "suggest": {
+                "ext-apc": ">=3.1.1",
+                "ext-couchbase": ">=2.0.0",
+                "ext-memcached": ">=2.0.0",
+                "ext-pdo": ">=0.1.0",
+                "ext-redis": ">=2.2.0 || 0.0.0.0",
+                "league/flysystem": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MatthiasMullie\\Scrapbook\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Mullie",
+                    "email": "scrapbook@mullie.eu",
+                    "homepage": "https://www.mullie.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Scrapbook is a PHP cache library, with adapters for e.g. Memcached, Redis, Couchbase, APC(u), SQL and additional capabilities (e.g. transactions, stampede protection) built on top.",
+            "homepage": "https://scrapbook.cash",
+            "keywords": [
+                "Buffer",
+                "Flysystem",
+                "apc",
+                "buffered",
+                "cache",
+                "caching",
+                "commit",
+                "couchbase",
+                "filesystem",
+                "key",
+                "memcached",
+                "mitigation",
+                "mysql",
+                "postgresql",
+                "protection",
+                "psr-16",
+                "psr-6",
+                "psr-cache",
+                "psr-simple-cache",
+                "redis",
+                "rollback",
+                "sql",
+                "sqlite",
+                "stampede",
+                "store",
+                "transaction",
+                "transactional",
+                "value"
+            ],
+            "time": "2019-08-30T09:35:02+00:00"
         },
         {
             "name": "psr/cache",
@@ -1785,6 +2123,662 @@
                 "psr-6"
             ],
             "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "6d24de090cd59cfc830263cfba965be77b563c13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/6d24de090cd59cfc830263cfba965be77b563c13",
+                "reference": "6d24de090cd59cfc830263cfba965be77b563c13",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+            },
+            "suggest": {
+                "ext-event": "~1.0 for ExtEventLoop",
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
+                "ext-uv": "* for ExtUvLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "time": "2020-01-01T18:39:52+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/50426855f7a77ddf43b9266c22320df5bf6c6ce6",
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "time": "2019-01-01T16:15:09+00:00"
+        },
+        {
+            "name": "spatie/phpunit-watcher",
+            "version": "1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/phpunit-watcher.git",
+                "reference": "dee58ae54d3bc4eccc2b3d7006444f535a693f18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/phpunit-watcher/zipball/dee58ae54d3bc4eccc2b3d7006444f535a693f18",
+                "reference": "dee58ae54d3bc4eccc2b3d7006444f535a693f18",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stdio-react": "^2.0",
+                "jolicode/jolinotif": "^2.0",
+                "php": "^7.2",
+                "symfony/console": "^4.0|^5.0",
+                "symfony/process": "^4.0|^5.0",
+                "symfony/yaml": "^4.0|^5.0",
+                "yosymfony/resource-watcher": "^2.0"
+            },
+            "conflict": {
+                "yosymfony/resource-watcher": "<2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0"
+            },
+            "bin": [
+                "phpunit-watcher"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\PhpUnitWatcher\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatically rerun PHPUnit tests when source code changes",
+            "homepage": "https://github.com/spatie/phpunit-watcher",
+            "keywords": [
+                "phpunit-watcher",
+                "spatie"
+            ],
+            "time": "2020-01-04T22:46:42+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-30T11:42:42+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/600a52c29afc0d1caa74acbec8d3095ca7e9910d",
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e",
+                "reference": "c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "ad5e9c83ade5bbb3a96a3f30588a0622708caefd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ad5e9c83ade5bbb3a96a3f30588a0622708caefd",
+                "reference": "ad5e9c83ade5bbb3a96a3f30588a0622708caefd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "symfony/console": "^4.4|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-30T11:42:42+00:00"
+        },
+        {
+            "name": "yosymfony/resource-watcher",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yosymfony/resource-watcher.git",
+                "reference": "a8c34f704e6bd4f786c97f3c0ba65bd86cb2bd73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yosymfony/resource-watcher/zipball/a8c34f704e6bd4f786c97f3c0ba65bd86cb2bd73",
+                "reference": "a8c34f704e6bd4f786c97f3c0ba65bd86cb2bd73",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "symfony/finder": "^2.7|^3.0|^4.0|^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7",
+                "symfony/filesystem": "^2.7|^3.0|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Yosymfony\\ResourceWatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Victor Puertas",
+                    "email": "vpgugr@gmail.com"
+                }
+            ],
+            "description": "A simple resource watcher using Symfony Finder",
+            "homepage": "http://yosymfony.com",
+            "keywords": [
+                "finder",
+                "resources",
+                "symfony",
+                "watcher"
+            ],
+            "time": "2020-01-04T15:36:55+00:00"
         }
     ],
     "aliases": [],
@@ -1793,7 +2787,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3"
+        "php": ">=5.5"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "25dd230f8a43161eab823508c81681d8",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3"
+    },
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,228 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20479feb899ebdec6d67a8fd4482528a",
+    "content-hash": "63fc7052d316c03bedd652d9f33ddbca",
     "packages": [
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "clue/stdio-react",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-stdio.git",
+                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-stdio/zipball/5f42a3a5a29f52432f0f68b57890353e8ca65069",
+                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069",
+                "shasum": ""
+            },
+            "require": {
+                "clue/term-react": "^1.0 || ^0.1.1",
+                "clue/utf8-react": "^1.0 || ^0.1",
+                "php": ">=5.3",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+                "react/stream": "^1.0 || ^0.7 || ^0.6"
+            },
+            "require-dev": {
+                "clue/arguments": "^2.0",
+                "clue/commander": "^1.2",
+                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+            },
+            "suggest": {
+                "ext-mbstring": "Using ext-mbstring should provide slightly better performance for handling I/O"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Stdio\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Async, event-driven console input & output (STDIN, STDOUT) for truly interactive CLI applications, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/reactphp-stdio",
+            "keywords": [
+                "async",
+                "autocomplete",
+                "autocompletion",
+                "cli",
+                "history",
+                "interactive",
+                "reactphp",
+                "readline",
+                "stdin",
+                "stdio",
+                "stdout"
+            ],
+            "time": "2019-08-28T12:01:30+00:00"
+        },
+        {
+            "name": "clue/term-react",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-term.git",
+                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-term/zipball/3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
+                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.0 || ^0.7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Term\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Streaming terminal emulator, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/reactphp-term",
+            "keywords": [
+                "C0",
+                "CSI",
+                "ansi",
+                "apc",
+                "ascii",
+                "c1",
+                "control codes",
+                "dps",
+                "osc",
+                "pm",
+                "reactphp",
+                "streaming",
+                "terminal",
+                "vt100",
+                "xterm"
+            ],
+            "time": "2018-07-09T08:20:33+00:00"
+        },
+        {
+            "name": "clue/utf8-react",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-utf8-react.git",
+                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-utf8-react/zipball/c6111a22e1056627c119233ff5effe00f5d3cc1d",
+                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4 || ^0.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8",
+                "react/stream": "^1.0 || ^0.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Utf8\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Streaming UTF-8 parser, built on top of ReactPHP",
+            "homepage": "https://github.com/clue/php-utf8-react",
+            "keywords": [
+                "reactphp",
+                "streaming",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "time": "2017-07-06T07:43:22+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.3.0",
@@ -61,6 +281,390 @@
                 "instantiate"
             ],
             "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
+                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Evenement": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "time": "2017-07-23T21:35:13+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20T08:20:44+00:00"
+        },
+        {
+            "name": "jolicode/jolinotif",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jolicode/JoliNotif.git",
+                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/b1a7ccfeb13f1daa12a5188531863b739e388e13",
+                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "symfony/process": "^3.3|^4.0|^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "symfony/finder": "^3.3|^4.0|^5.0",
+                "symfony/phpunit-bridge": "^3.4.26|^4.0|^5.0"
+            },
+            "bin": [
+                "jolinotif"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joli\\JoliNotif\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïck Piera",
+                    "email": "pyrech@gmail.com"
+                }
+            ],
+            "description": "Send desktop notifications on Windows, Linux, MacOS.",
+            "keywords": [
+                "MAC",
+                "growl",
+                "linux",
+                "notification",
+                "windows"
+            ],
+            "time": "2020-01-10T15:37:00+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.66",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/021569195e15f8209b1c4bebb78bd66aa4f08c21",
+                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7.26"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2020-03-17T18:58:12+00:00"
+        },
+        {
+            "name": "matthiasmullie/scrapbook",
+            "version": "1.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matthiasmullie/scrapbook.git",
+                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matthiasmullie/scrapbook/zipball/d27ff1ab823f288918d3c593cd3c7e56db0e7745",
+                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0",
+                "psr/cache": "~1.0",
+                "psr/simple-cache": "~1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "~1.0",
+                "psr/simple-cache-implementation": "~1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.0",
+                "phpunit/phpunit": "~4.8|~5.0|~6.0"
+            },
+            "suggest": {
+                "ext-apc": ">=3.1.1",
+                "ext-couchbase": ">=2.0.0",
+                "ext-memcached": ">=2.0.0",
+                "ext-pdo": ">=0.1.0",
+                "ext-redis": ">=2.2.0 || 0.0.0.0",
+                "league/flysystem": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MatthiasMullie\\Scrapbook\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Mullie",
+                    "email": "scrapbook@mullie.eu",
+                    "homepage": "https://www.mullie.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Scrapbook is a PHP cache library, with adapters for e.g. Memcached, Redis, Couchbase, APC(u), SQL and additional capabilities (e.g. transactions, stampede protection) built on top.",
+            "homepage": "https://scrapbook.cash",
+            "keywords": [
+                "Buffer",
+                "Flysystem",
+                "apc",
+                "buffered",
+                "cache",
+                "caching",
+                "commit",
+                "couchbase",
+                "filesystem",
+                "key",
+                "memcached",
+                "mitigation",
+                "mysql",
+                "postgresql",
+                "protection",
+                "psr-16",
+                "psr-6",
+                "psr-cache",
+                "psr-simple-cache",
+                "redis",
+                "rollback",
+                "sql",
+                "sqlite",
+                "stampede",
+                "store",
+                "transaction",
+                "transactional",
+                "value"
+            ],
+            "time": "2019-08-30T09:35:02+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2019-12-26T09:49:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -739,16 +1343,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.0.1",
+            "version": "9.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76"
+                "reference": "c0ecbfb898ab8b24d8a59a23520f7b2a73e27b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68d7e5b17a6b9461e17c00446caa409863154f76",
-                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c0ecbfb898ab8b24d8a59a23520f7b2a73e27b5b",
+                "reference": "c0ecbfb898ab8b24d8a59a23520f7b2a73e27b5b",
                 "shasum": ""
             },
             "require": {
@@ -764,14 +1368,14 @@
                 "phar-io/version": "^2.0.1",
                 "php": "^7.3",
                 "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^8.0",
+                "phpunit/php-code-coverage": "^8.0.1",
                 "phpunit/php-file-iterator": "^3.0",
                 "phpunit/php-invoker": "^3.0",
                 "phpunit/php-text-template": "^2.0",
                 "phpunit/php-timer": "^3.0",
                 "sebastian/comparator": "^4.0",
                 "sebastian/diff": "^4.0",
-                "sebastian/environment": "^5.0",
+                "sebastian/environment": "^5.0.1",
                 "sebastian/exporter": "^4.0",
                 "sebastian/global-state": "^4.0",
                 "sebastian/object-enumerator": "^4.0",
@@ -821,20 +1425,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-02-13T07:30:12+00:00"
+            "time": "2020-03-31T08:57:51+00:00"
         },
         {
-            "name": "psr/simple-cache",
+            "name": "psr/cache",
             "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
@@ -848,7 +1452,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
+                    "Psr\\Cache\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -861,15 +1465,150 @@
                     "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for simple caching",
+            "description": "Common interface for caching libraries",
             "keywords": [
                 "cache",
-                "caching",
                 "psr",
-                "psr-16",
-                "simple-cache"
+                "psr-6"
             ],
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "6d24de090cd59cfc830263cfba965be77b563c13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/6d24de090cd59cfc830263cfba965be77b563c13",
+                "reference": "6d24de090cd59cfc830263cfba965be77b563c13",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+            },
+            "suggest": {
+                "ext-event": "~1.0 for ExtEventLoop",
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
+                "ext-uv": "* for ExtUvLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "time": "2020-01-01T18:39:52+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/50426855f7a77ddf43b9266c22320df5bf6c6ce6",
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "time": "2019-01-01T16:15:09+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1038,16 +1777,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb"
+                "reference": "c39c1db0a5cffc98173f3de5a17d489d1043fd7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
-                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/c39c1db0a5cffc98173f3de5a17d489d1043fd7b",
+                "reference": "c39c1db0a5cffc98173f3de5a17d489d1043fd7b",
                 "shasum": ""
             },
             "require": {
@@ -1087,7 +1826,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2020-02-19T13:40:20+00:00"
+            "time": "2020-03-31T12:14:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1490,891 +2229,6 @@
             "time": "2020-01-21T06:36:37+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.15-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2020-02-27T09:26:54+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "vimeo/psalm": "<3.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2020-02-14T12:15:55+00:00"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "clue/stdio-react",
-            "version": "v2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/clue/reactphp-stdio.git",
-                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/clue/reactphp-stdio/zipball/5f42a3a5a29f52432f0f68b57890353e8ca65069",
-                "reference": "5f42a3a5a29f52432f0f68b57890353e8ca65069",
-                "shasum": ""
-            },
-            "require": {
-                "clue/term-react": "^1.0 || ^0.1.1",
-                "clue/utf8-react": "^1.0 || ^0.1",
-                "php": ">=5.3",
-                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-                "react/stream": "^1.0 || ^0.7 || ^0.6"
-            },
-            "require-dev": {
-                "clue/arguments": "^2.0",
-                "clue/commander": "^1.2",
-                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
-            },
-            "suggest": {
-                "ext-mbstring": "Using ext-mbstring should provide slightly better performance for handling I/O"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Clue\\React\\Stdio\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@lueck.tv"
-                }
-            ],
-            "description": "Async, event-driven console input & output (STDIN, STDOUT) for truly interactive CLI applications, built on top of ReactPHP",
-            "homepage": "https://github.com/clue/reactphp-stdio",
-            "keywords": [
-                "async",
-                "autocomplete",
-                "autocompletion",
-                "cli",
-                "history",
-                "interactive",
-                "reactphp",
-                "readline",
-                "stdin",
-                "stdio",
-                "stdout"
-            ],
-            "time": "2019-08-28T12:01:30+00:00"
-        },
-        {
-            "name": "clue/term-react",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/clue/reactphp-term.git",
-                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/clue/reactphp-term/zipball/3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
-                "reference": "3cec1164073455a85a3f2b3c3fe6db2170d21c2a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "react/stream": "^1.0 || ^0.7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.0 || ^4.8",
-                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Clue\\React\\Term\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@lueck.tv"
-                }
-            ],
-            "description": "Streaming terminal emulator, built on top of ReactPHP",
-            "homepage": "https://github.com/clue/reactphp-term",
-            "keywords": [
-                "C0",
-                "CSI",
-                "ansi",
-                "apc",
-                "ascii",
-                "c1",
-                "control codes",
-                "dps",
-                "osc",
-                "pm",
-                "reactphp",
-                "streaming",
-                "terminal",
-                "vt100",
-                "xterm"
-            ],
-            "time": "2018-07-09T08:20:33+00:00"
-        },
-        {
-            "name": "clue/utf8-react",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/clue/php-utf8-react.git",
-                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-utf8-react/zipball/c6111a22e1056627c119233ff5effe00f5d3cc1d",
-                "reference": "c6111a22e1056627c119233ff5effe00f5d3cc1d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4 || ^0.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.0 || ^4.8",
-                "react/stream": "^1.0 || ^0.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Clue\\React\\Utf8\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@lueck.tv"
-                }
-            ],
-            "description": "Streaming UTF-8 parser, built on top of ReactPHP",
-            "homepage": "https://github.com/clue/php-utf8-react",
-            "keywords": [
-                "reactphp",
-                "streaming",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "time": "2017-07-06T07:43:22+00:00"
-        },
-        {
-            "name": "evenement/evenement",
-            "version": "v3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/igorw/evenement.git",
-                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/igorw/evenement/zipball/531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
-                "reference": "531bfb9d15f8aa57454f5f0285b18bec903b8fb7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Evenement": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                }
-            ],
-            "description": "Événement is a very simple event dispatching library for PHP",
-            "keywords": [
-                "event-dispatcher",
-                "event-emitter"
-            ],
-            "time": "2017-07-23T21:35:13+00:00"
-        },
-        {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "time": "2016-01-20T08:20:44+00:00"
-        },
-        {
-            "name": "jolicode/jolinotif",
-            "version": "v2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jolicode/JoliNotif.git",
-                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/b1a7ccfeb13f1daa12a5188531863b739e388e13",
-                "reference": "b1a7ccfeb13f1daa12a5188531863b739e388e13",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0",
-                "symfony/process": "^3.3|^4.0|^5.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "symfony/finder": "^3.3|^4.0|^5.0",
-                "symfony/phpunit-bridge": "^3.4.26|^4.0|^5.0"
-            },
-            "bin": [
-                "jolinotif"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Joli\\JoliNotif\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Loïck Piera",
-                    "email": "pyrech@gmail.com"
-                }
-            ],
-            "description": "Send desktop notifications on Windows, Linux, MacOS.",
-            "keywords": [
-                "MAC",
-                "growl",
-                "linux",
-                "notification",
-                "windows"
-            ],
-            "time": "2020-01-10T15:37:00+00:00"
-        },
-        {
-            "name": "league/flysystem",
-            "version": "1.0.66",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/021569195e15f8209b1c4bebb78bd66aa4f08c21",
-                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21",
-                "shasum": ""
-            },
-            "require": {
-                "ext-fileinfo": "*",
-                "php": ">=5.5.9"
-            },
-            "conflict": {
-                "league/flysystem-sftp": "<1.0.6"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7.26"
-            },
-            "suggest": {
-                "ext-fileinfo": "Required for MimeType",
-                "ext-ftp": "Allows you to use FTP server storage",
-                "ext-openssl": "Allows you to use FTPS server storage",
-                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-                "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Flysystem\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
-                }
-            ],
-            "description": "Filesystem abstraction: Many filesystems, one API.",
-            "keywords": [
-                "Cloud Files",
-                "WebDAV",
-                "abstraction",
-                "aws",
-                "cloud",
-                "copy.com",
-                "dropbox",
-                "file systems",
-                "files",
-                "filesystem",
-                "filesystems",
-                "ftp",
-                "rackspace",
-                "remote",
-                "s3",
-                "sftp",
-                "storage"
-            ],
-            "time": "2020-03-17T18:58:12+00:00"
-        },
-        {
-            "name": "matthiasmullie/scrapbook",
-            "version": "1.4.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/matthiasmullie/scrapbook.git",
-                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/scrapbook/zipball/d27ff1ab823f288918d3c593cd3c7e56db0e7745",
-                "reference": "d27ff1ab823f288918d3c593cd3c7e56db0e7745",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0",
-                "psr/cache": "~1.0",
-                "psr/simple-cache": "~1.0"
-            },
-            "provide": {
-                "psr/cache-implementation": "~1.0",
-                "psr/simple-cache-implementation": "~1.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.0",
-                "phpunit/phpunit": "~4.8|~5.0|~6.0"
-            },
-            "suggest": {
-                "ext-apc": ">=3.1.1",
-                "ext-couchbase": ">=2.0.0",
-                "ext-memcached": ">=2.0.0",
-                "ext-pdo": ">=0.1.0",
-                "ext-redis": ">=2.2.0 || 0.0.0.0",
-                "league/flysystem": "~1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MatthiasMullie\\Scrapbook\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matthias Mullie",
-                    "email": "scrapbook@mullie.eu",
-                    "homepage": "https://www.mullie.eu",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Scrapbook is a PHP cache library, with adapters for e.g. Memcached, Redis, Couchbase, APC(u), SQL and additional capabilities (e.g. transactions, stampede protection) built on top.",
-            "homepage": "https://scrapbook.cash",
-            "keywords": [
-                "Buffer",
-                "Flysystem",
-                "apc",
-                "buffered",
-                "cache",
-                "caching",
-                "commit",
-                "couchbase",
-                "filesystem",
-                "key",
-                "memcached",
-                "mitigation",
-                "mysql",
-                "postgresql",
-                "protection",
-                "psr-16",
-                "psr-6",
-                "psr-cache",
-                "psr-simple-cache",
-                "redis",
-                "rollback",
-                "sql",
-                "sqlite",
-                "stampede",
-                "store",
-                "transaction",
-                "transactional",
-                "value"
-            ],
-            "time": "2019-08-30T09:35:02+00:00"
-        },
-        {
-            "name": "mockery/mockery",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mockery/mockery.git",
-                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
-                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
-                "shasum": ""
-            },
-            "require": {
-                "hamcrest/hamcrest-php": "~2.0",
-                "lib-pcre": ">=7.0",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                },
-                {
-                    "name": "Dave Marshall",
-                    "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
-                }
-            ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework",
-            "homepage": "https://github.com/mockery/mockery",
-            "keywords": [
-                "BDD",
-                "TDD",
-                "library",
-                "mock",
-                "mock objects",
-                "mockery",
-                "stub",
-                "test",
-                "test double",
-                "testing"
-            ],
-            "time": "2019-12-26T09:49:15+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
-            "name": "react/event-loop",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "6d24de090cd59cfc830263cfba965be77b563c13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/6d24de090cd59cfc830263cfba965be77b563c13",
-                "reference": "6d24de090cd59cfc830263cfba965be77b563c13",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
-            },
-            "suggest": {
-                "ext-event": "~1.0 for ExtEventLoop",
-                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
-                "ext-uv": "* for ExtUvLoop"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\EventLoop\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
-            "keywords": [
-                "asynchronous",
-                "event-loop"
-            ],
-            "time": "2020-01-01T18:39:52+00:00"
-        },
-        {
-            "name": "react/stream",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/stream.git",
-                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/50426855f7a77ddf43b9266c22320df5bf6c6ce6",
-                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6",
-                "shasum": ""
-            },
-            "require": {
-                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-                "php": ">=5.3.8",
-                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5"
-            },
-            "require-dev": {
-                "clue/stream-filter": "~1.2",
-                "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Stream\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
-            "keywords": [
-                "event-driven",
-                "io",
-                "non-blocking",
-                "pipe",
-                "reactphp",
-                "readable",
-                "stream",
-                "writable"
-            ],
-            "time": "2019-01-01T16:15:09+00:00"
-        },
-        {
             "name": "spatie/phpunit-watcher",
             "version": "1.22.0",
             "source": {
@@ -2556,6 +2410,64 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2020-03-27T16:56:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2916,6 +2828,94 @@
             "time": "2020-03-30T11:42:42+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2020-02-14T12:15:55+00:00"
+        },
+        {
             "name": "yosymfony/resource-watcher",
             "version": "v2.0.1",
             "source": {
@@ -2975,7 +2975,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-simplexml": "*"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "ext-simplexml": "*"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,825 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c241a6c0869218fd8153ad74866b2d7a",
+    "content-hash": "cc8e1ca37f622f4652721ec7dc9a13d8",
     "packages": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2018-08-07T13:53:10+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-22T12:28:44+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.3",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-token-stream": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^2.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/version": "^3.0",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-02-19T13:41:19+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2020-02-07T06:05:22+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-02-07T06:06:11+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2020-02-01T07:43:44+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2020-02-07T06:08:11+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2020-02-07T06:19:00+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68d7e5b17a6b9461e17c00446caa409863154f76",
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.3",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^8.0",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-invoker": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-timer": "^3.0",
+                "sebastian/comparator": "^4.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/exporter": "^4.0",
+                "sebastian/global-state": "^4.0",
+                "sebastian/object-enumerator": "^4.0",
+                "sebastian/resource-operations": "^3.0",
+                "sebastian/type": "^2.0",
+                "sebastian/version": "^3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2020-02-13T07:30:12+00:00"
+        },
         {
             "name": "psr/simple-cache",
             "version": "1.0.1",
@@ -53,6 +870,770 @@
                 "simple-cache"
             ],
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2020-02-07T06:20:13+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2020-02-07T06:08:51+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2020-02-07T06:09:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2020-02-19T13:40:20+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2020-02-07T06:10:52+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2020-02-07T06:11:37+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67516b175550abad905dc952f43285957ef4363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
+                "reference": "e67516b175550abad905dc952f43285957ef4363",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2020-02-07T06:12:23+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-02-07T06:19:40+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-02-07T06:18:20+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2020-02-07T06:13:02+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2020-02-07T06:13:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2020-01-21T06:36:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2020-02-14T12:15:55+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25dd230f8a43161eab823508c81681d8",
-    "packages": [],
+    "content-hash": "c241a6c0869218fd8153ad74866b2d7a",
+    "packages": [
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap = "vendor/autoload.php"
+         backupGlobals               = "false"
+         backupStaticAttributes      = "false"
+         colors                      = "true"
+         convertErrorsToExceptions   = "true"
+         convertNoticesToExceptions  = "true"
+         convertWarningsToExceptions = "true"
+         processIsolation            = "false"
+         stopOnFailure               = "false">
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+
+</phpunit>

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -118,9 +118,17 @@ class TourCMS {
 		$response = $this->request_from_remote($path, $channel, $verb, $post_data);
 
 		if ($this->is_cachable($method)) {
+
+			$data_to_persist = null;
+			if($this->result_type === 'simplexml'){
+				$data_to_persist = $response->asXML();
+			}else{
+				$data_to_persist = $response;
+			}
+
 			$this->cache->set(
 				$cache_key,
-				$response->asXML(),
+				$data_to_persist,
 				$this->get_ttl_for_method($method)
 			);
 		}
@@ -158,6 +166,11 @@ class TourCMS {
 	}
 
 
+	/**
+	 * @author Cornelius Carstens
+	 * @param $path string
+	 * @return string
+	 */
 	protected function convert_path_to_cache_key($path)
 	{
 		return trim(

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -179,8 +179,10 @@ class TourCMS {
 
 		// Check whether we need to return raw XML or
 		// convert to SimpleXML first
-		if($this->result_type == "simplexml")
+		if($this->result_type == "simplexml"){
 			$result = simplexml_load_string($result);
+			$result->source = "remote";
+		}
 
 		return($result);
 	}
@@ -214,6 +216,7 @@ class TourCMS {
 		$response = $this->cache->get($key);
 		if($this->result_type === "simplexml"){
 			$response = new SimpleXMLElement($response);
+			$response->source = "cache";
 		}
 		return $response;
 	}

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -84,7 +84,7 @@ class TourCMS {
 	 * @author Cornelius Carstens
 	 * @return array
 	 */
-	public function getDefaultCacheTimeouts(): array
+	public function get_default_cache_timeouts(): array
 	{
 		return $this->default_cache_timeouts;
 	}
@@ -99,6 +99,8 @@ class TourCMS {
 	 * @return String or SimpleXML
 	 */
 	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
+		$replaced = $this->convert_path_to_cache_key($path);
+		dump($replaced);
 		if (!$this->cache) {
 			return $this->request_from_remote($path, $channel, $verb, $post_data);
 		}
@@ -107,6 +109,14 @@ class TourCMS {
 	public function request_from_cache($path)
 	{
 
+	}
+
+
+	protected function convert_path_to_cache_key($path)
+	{
+		return trim(
+				str_replace(["/", "?", "=", "&"], "_", $path),
+			"_");
 	}
 
 	protected function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -93,12 +93,13 @@ class TourCMS {
 	 * request
 	 *
 	 * @author Paul Slugocki
+	 * @param $method string name of api method that is being requested
 	 * @param $path API path to call
 	 * @param $channel Channel ID, defaults to zero
 	 * @param $verb HTTP Verb, defaults to GET
 	 * @return String or SimpleXML
 	 */
-	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
+	public function request($method, $path, $channel = 0, $verb = 'GET', $post_data = null) {
 		$replaced = $this->convert_path_to_cache_key($path);
 
 		if (!$this->cache) {
@@ -240,55 +241,55 @@ class TourCMS {
 	# API methods (Housekeeping)
 
 	public function api_rate_limit_status($channel = 0) {
-		return($this->request('/api/rate_limit_status.xml', $channel));
+		return($this->request(__FUNCTION__, '/api/rate_limit_status.xml', $channel));
 	}
 
 	# Channel methods
 
 	public function list_channels() {
-		return($this->request('/p/channels/list.xml'));
+		return($this->request(__FUNCTION__, '/p/channels/list.xml'));
 	}
 
 	public function show_channel($channel) {
-		return($this->request('/c/channel/show.xml', $channel));
+		return($this->request(__FUNCTION__, '/c/channel/show.xml', $channel));
 	}
 
 	public function channel_performance($channel = 0) {
 		if($channel==0)
-			return($this->request('/p/channels/performance.xml'));
+			return($this->request(__FUNCTION__, '/p/channels/performance.xml'));
 		else
-			return($this->request('/c/channel/performance.xml', $channel));
+			return($this->request(__FUNCTION__, '/c/channel/performance.xml', $channel));
 	}
 
 	# Tour/Hotel methods
 
 	public function search_tours($params = "", $channel = 0) {
 		if($channel==0)
-			return($this->request('/p/tours/search.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/tours/search.xml?'.$params));
 		else
-			return($this->request('/c/tours/search.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/tours/search.xml?'.$params, $channel));
 	}
 
 	public function search_hotels_range($params = "", $tour = "", $channel = 0) {
 		if($channel==0)
-			return($this->request('/p/hotels/search_range.xml?'.$params."&single_tour_id=".$tour));
+			return($this->request(__FUNCTION__, '/p/hotels/search_range.xml?'.$params."&single_tour_id=".$tour));
 		else
-			return($this->request('/c/hotels/search_range.xml?'.$params."&single_tour_id=".$tour, $channel));
+			return($this->request(__FUNCTION__, '/c/hotels/search_range.xml?'.$params."&single_tour_id=".$tour, $channel));
 	}
 
 	public function search_hotels_specific($params = "", $tour = "", $channel = 0) {
 		if($channel==0)
-			return($this->request('/p/hotels/search_avail.xml?'.$params."&single_tour_id=".$tour));
+			return($this->request(__FUNCTION__, '/p/hotels/search_avail.xml?'.$params."&single_tour_id=".$tour));
 		else
-			return($this->request('/c/hotels/search_avail.xml?'.$params."&single_tour_id=".$tour, $channel));
+			return($this->request(__FUNCTION__, '/c/hotels/search_avail.xml?'.$params."&single_tour_id=".$tour, $channel));
 	}
 
 	public function list_product_filters($channel = 0) {
-			return($this->request('/c/tours/filters.xml', $channel));
+			return($this->request(__FUNCTION__, '/c/tours/filters.xml', $channel));
 	}
 
 	public function update_tour($tour_data, $channel) {
-		return($this->request('/c/tour/update.xml', $channel, "POST", $tour_data));
+		return($this->request(__FUNCTION__, '/c/tour/update.xml', $channel, "POST", $tour_data));
 	}
 
 	public function update_tour_url($tour, $channel, $tour_url) {
@@ -302,25 +303,25 @@ class TourCMS {
 
 	public function list_tours($channel = 0, $params = "") {
 		if($channel==0)
-			return($this->request('/p/tours/list.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/tours/list.xml?'.$params));
 		else
-			return($this->request('/c/tours/list.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/tours/list.xml?'.$params, $channel));
 	}
 
 	public function list_tour_images($channel = 0, $params = "")
 	{
 		if($channel==0)
-			return($this->request('/p/tours/images/list.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/tours/images/list.xml?'.$params));
 		else
-			return($this->request('/c/tours/images/list.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/tours/images/list.xml?'.$params, $channel));
 	}
 
 	public function list_tour_locations($channel = 0, $params = "")
 	{
 		if($channel==0)
-			return($this->request('/p/tours/locations.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/tours/locations.xml?'.$params));
 		else
-			return($this->request('/c/tours/locations.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/tours/locations.xml?'.$params, $channel));
 	}
 
 
@@ -351,30 +352,30 @@ class TourCMS {
 			}
 
 		if((int)$tour > 0) {
-			return($this->request($url, $channel));
+			return($this->request(__FUNCTION__, $url, $channel));
 		}
 	}
 
 
 	public function check_tour_availability($params, $tour, $channel)
 	{
-		return ($this->request('/c/tour/datesprices/checkavail.xml?id='.$tour."&".$params, $channel));
+		return ($this->request(__FUNCTION__, '/c/tour/datesprices/checkavail.xml?id='.$tour."&".$params, $channel));
 	}
 
 	public function show_tour_datesanddeals($tour, $channel, $qs = "")
 	{
-		return($this->request('/c/tour/datesprices/datesndeals/search.xml?id='.$tour.'&'.$qs, $channel));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/datesndeals/search.xml?id='.$tour.'&'.$qs, $channel));
 	}
 
 
 	public function show_tour_departures($tour, $channel, $qs = "")
 	{
-		return($this->request('/c/tour/datesprices/dep/show.xml?id='.$tour.'&'.$qs, $channel));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/show.xml?id='.$tour.'&'.$qs, $channel));
 	}
 
 	public function show_tour_freesale($tour, $channel)
 	{
-		return($this->request('/c/tour/datesprices/freesale/show.xml?id='.$tour, $channel));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/freesale/show.xml?id='.$tour, $channel));
 	}
 
 	/*
@@ -383,27 +384,27 @@ class TourCMS {
 
 	public function search_raw_departures($tour, $channel, $qs)
 	{
-		return($this->request('/c/tour/datesprices/dep/manage/search.xml?id='.$tour.'&'.$qs, $channel));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/manage/search.xml?id='.$tour.'&'.$qs, $channel));
 	}
 
 	public function show_departure($departure, $tour, $channel)
 	{
-		return($this->request('/c/tour/datesprices/dep/manage/show.xml?id='.$tour.'&departure_id='.$departure, $channel));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/manage/show.xml?id='.$tour.'&departure_id='.$departure, $channel));
 	}
 
 	public function create_departure($departure_data, $channel)
 	{
-		return($this->request('/c/tour/datesprices/dep/manage/new.xml', $channel, "POST", $departure_data));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/manage/new.xml', $channel, "POST", $departure_data));
 	}
 
 	public function update_departure($departure_data, $channel)
 	{
-		return($this->request('/c/tour/datesprices/dep/manage/update.xml', $channel, "POST", $departure_data));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/manage/update.xml', $channel, "POST", $departure_data));
 	}
 
 	public function delete_departure($departure, $tour, $channel)
 	{
-		return($this->request('/c/tour/datesprices/dep/manage/delete.xml?id='.$tour.'&departure_id='.$departure, $channel, "POST"));
+		return($this->request(__FUNCTION__, '/c/tour/datesprices/dep/manage/delete.xml?id='.$tour.'&departure_id='.$departure, $channel, "POST"));
 	}
 
 	/*
@@ -412,7 +413,7 @@ class TourCMS {
 
 	public function show_promo($promo, $channel)
 	{
-		return($this->request('/c/promo/show.xml?promo_code='.$promo, $channel));
+		return($this->request(__FUNCTION__, '/c/promo/show.xml?promo_code='.$promo, $channel));
 	}
 
 	# Booking methods
@@ -423,17 +424,17 @@ class TourCMS {
 
 	public function get_booking_redirect_url($url_data, $channel)
 	{
-		return($this->request('/c/booking/new/get_redirect_url.xml', $channel, "POST", $url_data));
+		return($this->request(__FUNCTION__, '/c/booking/new/get_redirect_url.xml', $channel, "POST", $url_data));
 	}
 
 	public function start_new_booking($booking_data, $channel)
 	{
-		return($this->request('/c/booking/new/start.xml', $channel, "POST", $booking_data));
+		return($this->request(__FUNCTION__, '/c/booking/new/start.xml', $channel, "POST", $booking_data));
 	}
 
 	public function commit_new_booking($booking_data, $channel)
 	{
-		return($this->request('/c/booking/new/commit.xml', $channel, "POST", $booking_data));
+		return($this->request(__FUNCTION__, '/c/booking/new/commit.xml', $channel, "POST", $booking_data));
 	}
 
 	/*
@@ -443,13 +444,13 @@ class TourCMS {
 	public function search_bookings($params = "", $channel = 0)
 	{
 		if($channel==0)
-			return($this->request('/p/bookings/search.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/bookings/search.xml?'.$params));
 		else
-			return($this->request('/c/bookings/search.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/bookings/search.xml?'.$params, $channel));
 	}
 
 	public function show_booking($booking, $channel) {
-		return($this->request('/c/booking/show.xml?booking_id='.$booking, $channel));
+		return($this->request(__FUNCTION__, '/c/booking/show.xml?booking_id='.$booking, $channel));
 	}
 
 	public function search_voucher($voucher_data = null, $channel = 0) {
@@ -460,9 +461,9 @@ class TourCMS {
 		}
 
 		if($channel == 0) {
-			return($this->request('/p/voucher/search.xml', $channel, 'POST', $voucher_data));
+			return($this->request(__FUNCTION__, '/p/voucher/search.xml', $channel, 'POST', $voucher_data));
 		} else {
-			return($this->request('/c/voucher/search.xml', $channel, 'POST', $voucher_data));
+			return($this->request(__FUNCTION__, '/c/voucher/search.xml', $channel, 'POST', $voucher_data));
 		}
 	}
 
@@ -472,53 +473,53 @@ class TourCMS {
 
 	public function update_booking($booking_data, $channel)
 	{
-		return($this->request('/c/booking/update.xml', $channel, "POST", $booking_data));
+		return($this->request(__FUNCTION__, '/c/booking/update.xml', $channel, "POST", $booking_data));
 	}
 
 	public function create_payment($payment_data, $channel)
 	{
-		return($this->request('/c/booking/payment/new.xml', $channel, "POST", $payment_data));
+		return($this->request(__FUNCTION__, '/c/booking/payment/new.xml', $channel, "POST", $payment_data));
 	}
 
 	public function log_failed_payment($payment_data, $channel)
 	{
-		return($this->request('/c/booking/payment/fail.xml', $channel, "POST", $payment_data));
+		return($this->request(__FUNCTION__, '/c/booking/payment/fail.xml', $channel, "POST", $payment_data));
 	}
 
 	public function spreedly_create_payment($payment_data, $channel)
 	{
-		return($this->request('/c/booking/payment/spreedly/new.xml', $channel, "POST", $payment_data));
+		return($this->request(__FUNCTION__, '/c/booking/payment/spreedly/new.xml', $channel, "POST", $payment_data));
 	}
 
 	public function spreedly_complete_payment($transaction_id, $channel)
 	{
-		return($this->request('/c/booking/gatewaytransaction/spreedlycomplete.xml?id=' . $transaction_id, $channel, 'POST'));
+		return($this->request(__FUNCTION__, '/c/booking/gatewaytransaction/spreedlycomplete.xml?id=' . $transaction_id, $channel, 'POST'));
 	}
 
 	public function cancel_booking($booking_data, $channel)
 	{
-		return($this->request('/c/booking/cancel.xml', $channel, "POST", $booking_data));
+		return($this->request(__FUNCTION__, '/c/booking/cancel.xml', $channel, "POST", $booking_data));
 	}
 
 	public function delete_booking($booking, $channel)
 	{
-		return($this->request('/c/booking/delete.xml?booking_id='.$booking, $channel, "POST"));
+		return($this->request(__FUNCTION__, '/c/booking/delete.xml?booking_id='.$booking, $channel, "POST"));
 	}
 
 	public function check_option_availability($booking, $tour_component_id, $channel){
-		return ($this->request('/c/booking/options/checkavail.xml?booking_id='.$booking.'&tour_component_id='.$tour_component_id, $channel));
+		return ($this->request(__FUNCTION__, '/c/booking/options/checkavail.xml?booking_id='.$booking.'&tour_component_id='.$tour_component_id, $channel));
 	}
 
 	public function booking_add_component($component_data, $channel){
-		return($this->request('/c/booking/component/new.xml', $channel, "POST", $component_data));
+		return($this->request(__FUNCTION__, '/c/booking/component/new.xml', $channel, "POST", $component_data));
 	}
 
 	public function booking_remove_component($component_data, $channel){
-		return($this->request('/c/booking/component/delete.xml', $channel, "POST", $component_data));
+		return($this->request(__FUNCTION__, '/c/booking/component/delete.xml', $channel, "POST", $component_data));
 	}
 
 	public function booking_update_component($component_data, $channel){
-		return($this->request('/c/booking/component/update.xml', $channel, "POST", $component_data));
+		return($this->request(__FUNCTION__, '/c/booking/component/update.xml', $channel, "POST", $component_data));
 	}
 
 	public function add_note_to_booking($booking, $channel, $text, $note_type) {
@@ -529,82 +530,82 @@ class TourCMS {
 		$note->addChild('text', $text);
 		$note->addChild('type', $note_type);
 
-		return($this->request('/c/booking/note/new.xml', $channel, 'POST', $booking_data));
+		return($this->request(__FUNCTION__, '/c/booking/note/new.xml', $channel, 'POST', $booking_data));
 	}
 
 	public function send_booking_email($booking_data, $channel){
-			return($this->request('/c/booking/email/send.xml', $channel, "POST", $booking_data));
+			return($this->request(__FUNCTION__, '/c/booking/email/send.xml', $channel, "POST", $booking_data));
 	}
 
 	public function redeem_voucher($voucher_data, $channel = 0) {
-		return($this->request('/c/voucher/redeem.xml', $channel, 'POST', $voucher_data));
+		return($this->request(__FUNCTION__, '/c/voucher/redeem.xml', $channel, 'POST', $voucher_data));
 	}
 
 	# Enquiry and customer methods
 
 	public function create_enquiry($enquiry_data, $channel)
 	{
-		return($this->request('/c/enquiry/new.xml', $channel, "POST", $enquiry_data));
+		return($this->request(__FUNCTION__, '/c/enquiry/new.xml', $channel, "POST", $enquiry_data));
 	}
 
 	public function update_customer($customer_data, $channel)
 	{
-		return($this->request('/c/customer/update.xml', $channel, "POST", $customer_data));
+		return($this->request(__FUNCTION__, '/c/customer/update.xml', $channel, "POST", $customer_data));
 	}
 
 	public function search_enquiries($params = "", $channel = 0) {
 		if($channel==0)
-			return($this->request('/p/enquiries/search.xml?'.$params));
+			return($this->request(__FUNCTION__, '/p/enquiries/search.xml?'.$params));
 		else
-			return($this->request('/c/enquiries/search.xml?'.$params, $channel));
+			return($this->request(__FUNCTION__, '/c/enquiries/search.xml?'.$params, $channel));
 	}
 
 	public function show_enquiry($enquiry, $channel)
 	{
-		return($this->request('/c/enquiry/show.xml?enquiry_id='.$enquiry, $channel));
+		return($this->request(__FUNCTION__, '/c/enquiry/show.xml?enquiry_id='.$enquiry, $channel));
 	}
 
 	public function show_customer($customer, $channel)
 	{
-		return($this->request('/c/customer/show.xml?customer_id='.$customer, $channel));
+		return($this->request(__FUNCTION__, '/c/customer/show.xml?customer_id='.$customer, $channel));
 	}
 
 	public function check_customer_login($customer, $password, $channel) {
-		return($this->request('/c/customers/login_search.xml?customer_username='.$customer.'&customer_password='.$password, $channel));
+		return($this->request(__FUNCTION__, '/c/customers/login_search.xml?customer_username='.$customer.'&customer_password='.$password, $channel));
 	}
 
 	# Agents
 	public function search_agents($params, $channel)
 	{
-		return($this->request('/c/agents/search.xml?'.$params, $channel));
+		return($this->request(__FUNCTION__, '/c/agents/search.xml?'.$params, $channel));
 	}
 
   	public function start_new_agent_login($params, $channel)
 	{
-		return($this->request('/c/start_agent_login.xml', $channel, "POST", $params));
+		return($this->request(__FUNCTION__, '/c/start_agent_login.xml', $channel, "POST", $params));
 	}
 
 	public function retrieve_agent_booking_key($private_token, $channel)
 	{
-		return($this->request('/c/retrieve_agent_booking_key.xml?k='.$private_token, $channel));
+		return($this->request(__FUNCTION__, '/c/retrieve_agent_booking_key.xml?k='.$private_token, $channel));
   	}
 
 	# Payments
   	public function list_payments($params, $channel)
   	{
-        return($this->request('/c/booking/payment/list.xml?'.$params, $channel));
+        return($this->request(__FUNCTION__, '/c/booking/payment/list.xml?'.$params, $channel));
   	}
 
 	# Staff members
   	public function list_staff_members($channel)
   	{
-        return($this->request('/c/staff/list.xml', $channel));
+        return($this->request(__FUNCTION__, '/c/staff/list.xml', $channel));
   	}
 
 	# Internal supplier methods
 	public function show_supplier($supplier, $channel)
 	{
-		return($this->request('/c/supplier/show.xml?supplier_id='.$supplier, $channel));
+		return($this->request(__FUNCTION__, '/c/supplier/show.xml?supplier_id='.$supplier, $channel));
 	}
 
 	# Used for validating webhook signatures
@@ -641,22 +642,22 @@ class TourCMS {
 	public function list_pickups($query_string, $channel)
 	{
 		if (substr($query_string, 0,1) !== '?') $query_string = '?' . $query_string;
-		return ($this->request('/c/pickups/list.xml' . $query_string, $channel));
+		return ($this->request(__FUNCTION__, '/c/pickups/list.xml' . $query_string, $channel));
 	}
 
 	public function create_pickup($pickup_data, $channel)
 	{
-		return ($this->request('/c/pickups/new.xml', $channel, "POST", $pickup_data));
+		return ($this->request(__FUNCTION__, '/c/pickups/new.xml', $channel, "POST", $pickup_data));
 	}
 
 	public function update_pickup($pickup_data, $channel)
 	{
-		return ($this->request('/c/pickups/update.xml', $channel, "POST", $pickup_data));
+		return ($this->request(__FUNCTION__, '/c/pickups/update.xml', $channel, "POST", $pickup_data));
 	}
 
 	public function delete_pickup($pickup_data, $channel)
 	{
-		return ($this->request('/c/pickups/delete.xml', $channel, "POST", $pickup_data));
+		return ($this->request(__FUNCTION__, '/c/pickups/delete.xml', $channel, "POST", $pickup_data));
 	}
 
 }

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -68,6 +68,11 @@ class TourCMS {
 	 * @return String or SimpleXML
 	 */
 	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
+		$this->request($path, $channel, $verb, $post_data);
+	}
+
+	public function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)
+	{
 		// Prepare the URL we are sending to
 		$url = $this->base_url.$path;
 		// We need a signature for the header
@@ -77,8 +82,8 @@ class TourCMS {
 
 		// Build headers
 		$headers = array("Content-type: text/xml;charset=\"utf-8\"",
-				 "Date: ".gmdate('D, d M Y H:i:s \G\M\T', $outbound_time),
-				 "Authorization: TourCMS $channel:$this->marketp_id:$signature");
+			"Date: ".gmdate('D, d M Y H:i:s \G\M\T', $outbound_time),
+			"Authorization: TourCMS $channel:$this->marketp_id:$signature");
 
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
@@ -96,8 +101,8 @@ class TourCMS {
 
 		if($verb == "POST") {
 			curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, 'POST' );
-				if(!is_null($post_data))
-					curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data->asXML());
+			if(!is_null($post_data))
+				curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data->asXML());
 		}
 
 		// Callback function to populate the response headers on curl_exec

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -42,7 +42,8 @@ class TourCMS {
 	protected $last_response_headers = array();
 	protected $cache = null;
 	protected $cache_timeouts = null;
-	protected $default_cache_timeouts = [
+
+	public static $default_cache_timeouts = [
 		"search_tours" => ["time" => 1800],
 		"show_tour" => ["time" => 3600],
 		"show_tour_datesanddeals" => ["time" => 900],
@@ -196,23 +197,12 @@ class TourCMS {
 	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
 	{
 		if(is_null($cache_timeouts)){
-			$cache_timeouts = $this->default_cache_timeouts;
+			$cache_timeouts = TourCMS::$default_cache_timeouts;
 		}
 
 		$this->cache = $cache;
 		$this->cache_timeouts = $cache_timeouts;
 	}
-
-
-	/**
-	 * @author Cornelius Carstens
-	 * @return array
-	 */
-	public function get_default_cache_timeouts()
-	{
-		return $this->default_cache_timeouts;
-	}
-
 
 	/**
 	 * @author Cornelius Carstens

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -95,7 +95,7 @@ class TourCMS {
 		}
 	}
 
-	protected function request_from_cache($path)
+	public function request_from_cache($path)
 	{
 
 	}

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -72,38 +72,6 @@ class TourCMS {
 	}
 
 	/**
-	 * @author Cornelius Carstens
-	 * @param CacheInterface $cache
-	 * @param array|null $cache_timeouts
-	 */
-	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
-	{
-		if(is_null($cache_timeouts)){
-			$cache_timeouts = $this->default_cache_timeouts;
-		}
-
-		$this->cache = $cache;
-		$this->cache_timeouts = $cache_timeouts;
-	}
-
-	/**
-	 * @author Cornelius Carstens
-	 * @return array
-	 */
-	public function get_default_cache_timeouts()
-	{
-		return $this->default_cache_timeouts;
-	}
-
-	/**
-	 * @return null
-	 */
-	public function getCacheTimeouts()
-	{
-		return $this->cache_timeouts;
-	}
-
-	/**
 	 * request
 	 *
 	 * @author Cornelius Carstens
@@ -139,59 +107,6 @@ class TourCMS {
 		}
 
 		return $response;
-	}
-
-	/**
-	 * @author Cornelius Carstens
-	 * @param $key
-	 * @return String | SimpleXMLElement
-	 */
-	public function request_from_cache($key)
-	{
-		$response = $this->cache->get($key);
-		if($this->result_type === "simplexml"){
-			$response = new SimpleXMLElement($response);
-		}
-		return $response;
-	}
-
-	/**
-	 * @author Cornelius Carstens
-	 * @param $method string api method name corresponding to key in cache_timeouts
-	 * @return integer
-	 */
-	protected function get_ttl_for_method($method)
-	{
-		return $this->cache_timeouts[$method]["time"];
-	}
-
-	/**
-	 * @author Cornelius Carstens
-	 * @param $method string api method name corresponding to key in cache_timeouts
-	 * @return bool
-	 */
-	protected function is_cachable($method)
-	{
-		return (
-			!is_null($this->cache) &&
-			!is_null($this->cache_timeouts) &&
-			array_key_exists($method, $this->cache_timeouts) &&
-			$this->cache_timeouts[$method]["time"] > 0
-		);
-	}
-
-
-	/**
-	 * converts a TourCMS api path to a psr-16 compliant cache key
-	 * @author Cornelius Carstens
-	 * @param $path string
-	 * @return string
-	 */
-	protected function convert_path_to_cache_key($path)
-	{
-		return trim(
-				str_replace(["/", "?", "=", "&"], "_", $path),
-			"_");
 	}
 
 	/**
@@ -268,6 +183,95 @@ class TourCMS {
 
 		return($result);
 	}
+
+	/********
+	 * 	PSR-16 Caching Methods
+	 *******/
+
+	/**
+	 * @author Cornelius Carstens
+	 * @param CacheInterface $cache
+	 * @param array|null $cache_timeouts
+	 */
+	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
+	{
+		if(is_null($cache_timeouts)){
+			$cache_timeouts = $this->default_cache_timeouts;
+		}
+
+		$this->cache = $cache;
+		$this->cache_timeouts = $cache_timeouts;
+	}
+
+
+	/**
+	 * @author Cornelius Carstens
+	 * @return array
+	 */
+	public function get_default_cache_timeouts()
+	{
+		return $this->default_cache_timeouts;
+	}
+
+
+	/**
+	 * @author Cornelius Carstens
+	 * @param $key
+	 * @return String | SimpleXMLElement
+	 */
+	public function request_from_cache($key)
+	{
+		$response = $this->cache->get($key);
+		if($this->result_type === "simplexml"){
+			$response = new SimpleXMLElement($response);
+		}
+		return $response;
+	}
+
+	/**
+	 * @author Cornelius Carstens
+	 * @param $method string api method name corresponding to key in cache_timeouts
+	 * @return integer
+	 */
+	protected function get_ttl_for_method($method)
+	{
+		return $this->cache_timeouts[$method]["time"];
+	}
+
+
+	/**
+	 * @author Cornelius Carstens
+	 * @param $method string api method name corresponding to key in cache_timeouts
+	 * @return bool
+	 */
+	protected function is_cachable($method)
+	{
+		return (
+			!is_null($this->cache) &&
+			!is_null($this->cache_timeouts) &&
+			array_key_exists($method, $this->cache_timeouts) &&
+			$this->cache_timeouts[$method]["time"] > 0
+		);
+	}
+
+
+	/**
+	 * converts a TourCMS api path to a psr-16 compliant cache key
+	 * @author Cornelius Carstens
+	 * @param $path string
+	 * @return string
+	 */
+	protected function convert_path_to_cache_key($path)
+	{
+		return trim(
+			str_replace(["/", "?", "=", "&"], "_", $path),
+			"_");
+	}
+
+	/********
+	 * 	END PSR-16 Caching Methods
+	 *******/
+
 
 	/**
 	 * get_base_url

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -102,13 +102,22 @@ class TourCMS {
 	public function request($method, $path, $channel = 0, $verb = 'GET', $post_data = null) {
 		$replaced = $this->convert_path_to_cache_key($path);
 
-		if (!$this->cache) {
+		if (!$this->is_cachable($method)) {
 			return $this->request_from_remote($path, $channel, $verb, $post_data);
 		}
 	}
 
 	public function request_from_cache($path)
 	{
+
+	}
+
+	protected function is_cachable($method)
+	{
+		return (
+			array_key_exists($method, $this->cache_timeouts) &&
+			$this->cache_timeouts[$method]["time"] > 0
+		);
 
 	}
 

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -68,7 +68,7 @@ class TourCMS {
 	 * @return String or SimpleXML
 	 */
 	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
-		$this->request($path, $channel, $verb, $post_data);
+		$this->request_from_remote($path, $channel, $verb, $post_data);
 	}
 
 	public function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -81,6 +81,15 @@ class TourCMS {
 	}
 
 	/**
+	 * @author Cornelius Carstens
+	 * @return array
+	 */
+	public function getDefaultCacheTimeouts(): array
+	{
+		return $this->default_cache_timeouts;
+	}
+
+	/**
 	 * request
 	 *
 	 * @author Paul Slugocki

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -85,7 +85,7 @@ class TourCMS {
 	 * @author Cornelius Carstens
 	 * @return array
 	 */
-	public function get_default_cache_timeouts(): array
+	public function get_default_cache_timeouts()
 	{
 		return $this->default_cache_timeouts;
 	}

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -66,11 +66,16 @@ class TourCMS {
 		$this->result_type = $res;
 		$this->timeout = $to;
 
-		if($cache){
+		if(!is_null($cache)){
 			$this->setup_cache($cache, $cache_timeouts);
 		}
 	}
 
+	/**
+	 * @author Cornelius Carstens
+	 * @param CacheInterface $cache
+	 * @param array|null $cache_timeouts
+	 */
 	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
 	{
 		if(is_null($cache_timeouts)){
@@ -136,6 +141,11 @@ class TourCMS {
 		return $response;
 	}
 
+	/**
+	 * @author Cornelius Carstens
+	 * @param $key
+	 * @return String | SimpleXMLElement
+	 */
 	public function request_from_cache($key)
 	{
 		$response = $this->cache->get($key);
@@ -145,6 +155,11 @@ class TourCMS {
 		return $response;
 	}
 
+	/**
+	 * @author Cornelius Carstens
+	 * @param $method string api method name corresponding to key in cache_timeouts
+	 * @return integer
+	 */
 	protected function get_ttl_for_method($method)
 	{
 		return $this->cache_timeouts[$method]["time"];
@@ -167,6 +182,7 @@ class TourCMS {
 
 
 	/**
+	 * converts a TourCMS api path to a psr-16 compliant cache key
 	 * @author Cornelius Carstens
 	 * @param $path string
 	 * @return string

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -104,7 +104,7 @@ class TourCMS {
 
 		$cache_key = $this->convert_path_to_cache_key($path);
 
-		if ($this->cache->has($cache_key)) {
+		if (!is_null($this->cache) && $this->cache->has($cache_key)) {
 			return $this->request_from_cache($cache_key);
 		}
 		$response = $this->request_from_remote($path, $channel, $verb, $post_data);

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 namespace TourCMS\Utils;
 
+use Psr\SimpleCache\CacheInterface;
 use \SimpleXMLElement;
 
 class TourCMS {
@@ -38,6 +39,7 @@ class TourCMS {
 	protected $result_type = "";
 	protected $timeout = 0;
 	protected $last_response_headers = array();
+	protected $cache = null;
 
 	/**
 	 * __construct
@@ -48,11 +50,12 @@ class TourCMS {
 	 * @param $res Result type, defaults to raw
 	 * @param $to Timeout, default 0
 	 */
-	public function __construct($mp, $k, $res = "raw", $to = 0) {
+	public function __construct($mp, $k, $res = "raw", $to = 0, CacheInterface $cache = null) {
 		$this->marketp_id = $mp;
 		$this->private_key = $k;
 		$this->result_type = $res;
 		$this->timeout = $to;
+		$this->cache = $cache;
 	}
 
 	/**

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -68,15 +68,17 @@ class TourCMS {
 	 * @return String or SimpleXML
 	 */
 	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
-		$this->request_from_remote($path, $channel, $verb, $post_data);
+		if (!$this->cache) {
+			return $this->request_from_remote($path, $channel, $verb, $post_data);
+		}
 	}
 
-	public function request_from_cache($path)
+	protected function request_from_cache($path)
 	{
 
 	}
 
-	public function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)
+	protected function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)
 	{
 		// Prepare the URL we are sending to
 		$url = $this->base_url.$path;

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -105,7 +105,7 @@ class TourCMS {
 		$cache_key = $this->convert_path_to_cache_key($path);
 
 		if ($this->cache->has($cache_key)) {
-			return false;
+			return $this->request_from_cache($cache_key);
 		}
 		$response = $this->request_from_remote($path, $channel, $verb, $post_data);
 
@@ -116,9 +116,13 @@ class TourCMS {
 		return $response;
 	}
 
-	public function request_from_cache($path)
+	public function request_from_cache($key)
 	{
-
+		$response = $this->cache->get($key);
+		if($this->result_type === "simplexml"){
+			$response = new SimpleXMLElement($response);
+		}
+		return $response;
 	}
 
 	/**

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -104,10 +104,16 @@ class TourCMS {
 
 		$cache_key = $this->convert_path_to_cache_key($path);
 
-		if ($this->can_be_retrieved_from_cache($method, $cache_key)) {
+		if ($this->cache->has($cache_key)) {
 			return false;
 		}
-		return $this->request_from_remote($path, $channel, $verb, $post_data);
+		$response = $this->request_from_remote($path, $channel, $verb, $post_data);
+
+		if ($this->is_cachable($method)) {
+			$this->cache->set($cache_key, $response->asXML());
+		}
+
+		return $response;
 	}
 
 	public function request_from_cache($path)
@@ -126,17 +132,6 @@ class TourCMS {
 			array_key_exists($method, $this->cache_timeouts) &&
 			$this->cache_timeouts[$method]["time"] > 0
 		);
-	}
-
-	/**
-	 * @author Cornelius Carstens
-	 * @param $method string api method name corresponding to key in cache_timeouts
-	 * @param $key string cache key based on request path
-	 * @return bool
-	 */
-	protected function can_be_retrieved_from_cache($method, $key)
-	{
-		return $this->is_cachable($method) && $this->cache->has($key);
 	}
 
 

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -100,7 +100,7 @@ class TourCMS {
 	 */
 	public function request($path, $channel = 0, $verb = 'GET', $post_data = null) {
 		$replaced = $this->convert_path_to_cache_key($path);
-		dump($replaced);
+
 		if (!$this->cache) {
 			return $this->request_from_remote($path, $channel, $verb, $post_data);
 		}

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -118,7 +118,11 @@ class TourCMS {
 		$response = $this->request_from_remote($path, $channel, $verb, $post_data);
 
 		if ($this->is_cachable($method)) {
-			$this->cache->set($cache_key, $response->asXML(), $this->get_ttl_for_method($method));
+			$this->cache->set(
+				$cache_key,
+				$response->asXML(),
+				$this->get_ttl_for_method($method)
+			);
 		}
 
 		return $response;
@@ -146,6 +150,8 @@ class TourCMS {
 	protected function is_cachable($method)
 	{
 		return (
+			!is_null($this->cache) &&
+			!is_null($this->cache_timeouts) &&
 			array_key_exists($method, $this->cache_timeouts) &&
 			$this->cache_timeouts[$method]["time"] > 0
 		);

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -71,6 +71,11 @@ class TourCMS {
 		$this->request_from_remote($path, $channel, $verb, $post_data);
 	}
 
+	public function request_from_cache($path)
+	{
+
+	}
+
 	public function request_from_remote($path, $channel = 0, $verb = 'GET', $post_data = null)
 	{
 		// Prepare the URL we are sending to

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -41,6 +41,14 @@ class TourCMS {
 	protected $last_response_headers = array();
 	protected $cache = null;
 	protected $cache_timeouts = null;
+	protected $default_cache_timeouts = [
+		"search_tours" => ["time" => 1800],
+		"show_tour" => ["time" => 3600],
+		"show_tour_datesanddeals" => ["time" => 900],
+		"list_channels" => ["time" => 3600],
+		"show_channel" => ["time" => 3600],
+		"show_supplier" => ["time" => 360]
+	];
 
 	/**
 	 * __construct
@@ -65,14 +73,7 @@ class TourCMS {
 	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
 	{
 		if(is_null($cache_timeouts)){
-			$cache_timeouts = [
-				"search_tours" => ["time" => 1800],
-				"show_tour" => ["time" => 3600],
-				"show_tour_datesanddeals" => ["time" => 900],
-				"list_channels" => ["time" => 3600],
-				"show_channel" => ["time" => 3600],
-				"show_supplier" => ["time" => 360]
-			];
+			$cache_timeouts = $this->default_cache_timeouts;
 		}
 
 		$this->cache = $cache;

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -40,6 +40,7 @@ class TourCMS {
 	protected $timeout = 0;
 	protected $last_response_headers = array();
 	protected $cache = null;
+	protected $cache_timeouts = null;
 
 	/**
 	 * __construct
@@ -50,12 +51,32 @@ class TourCMS {
 	 * @param $res Result type, defaults to raw
 	 * @param $to Timeout, default 0
 	 */
-	public function __construct($mp, $k, $res = "raw", $to = 0, CacheInterface $cache = null) {
+	public function __construct($mp, $k, $res = "raw", $to = 0, CacheInterface $cache = null, $cache_timeouts = null) {
 		$this->marketp_id = $mp;
 		$this->private_key = $k;
 		$this->result_type = $res;
 		$this->timeout = $to;
+
+		if($cache){
+			$this->setup_cache($cache, $cache_timeouts);
+		}
+	}
+
+	protected function setup_cache(CacheInterface $cache, array $cache_timeouts = null)
+	{
+		if(is_null($cache_timeouts)){
+			$cache_timeouts = [
+				"search_tours" => ["time" => 1800],
+				"show_tour" => ["time" => 3600],
+				"show_tour_datesanddeals" => ["time" => 900],
+				"list_channels" => ["time" => 3600],
+				"show_channel" => ["time" => 3600],
+				"show_supplier" => ["time" => 360]
+			];
+		}
+
 		$this->cache = $cache;
+		$this->cache_timeouts = $cache_timeouts;
 	}
 
 	/**

--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -91,6 +91,14 @@ class TourCMS {
 	}
 
 	/**
+	 * @return null
+	 */
+	public function getCacheTimeouts()
+	{
+		return $this->cache_timeouts;
+	}
+
+	/**
 	 * request
 	 *
 	 * @author Cornelius Carstens
@@ -110,7 +118,7 @@ class TourCMS {
 		$response = $this->request_from_remote($path, $channel, $verb, $post_data);
 
 		if ($this->is_cachable($method)) {
-			$this->cache->set($cache_key, $response->asXML());
+			$this->cache->set($cache_key, $response->asXML(), $this->get_ttl_for_method($method));
 		}
 
 		return $response;
@@ -123,6 +131,11 @@ class TourCMS {
 			$response = new SimpleXMLElement($response);
 		}
 		return $response;
+	}
+
+	protected function get_ttl_for_method($method)
+	{
+		return $this->cache_timeouts[$method]["time"];
 	}
 
 	/**

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -112,7 +112,8 @@ class TourCMSCachingTest extends TestCase
     public function it_returns_the_response_from_cache_when_there_is_one_persisted()
     {
         $tourcms = $this->getMockedTourCMS();
-        $this->cache->set('p_tours_search.xml', $this->getCachedResponse()->asXML());
+
+        $tourcms->search_tours();
 
         $response = $tourcms->search_tours();
 
@@ -207,7 +208,7 @@ class TourCMSCachingTest extends TestCase
             <response>
                 <request>POST /c/some/url.xml</request>
                 <error>OK</error>
-                <cached>1</cached>
+                <source>cache</source>
             </response>");
     }
 
@@ -217,7 +218,7 @@ class TourCMSCachingTest extends TestCase
             <response>
                 <request>POST /c/some/url.xml</request>
                 <error>OK</error>
-                <remote>1</remote>
+                <source>remote</source>
             </response>");
     }
 
@@ -231,14 +232,14 @@ class TourCMSCachingTest extends TestCase
 
     public function assertIsFromRemote(SimpleXMLElement $response)
     {
-        $remote = (integer) $response->remote;
-        $this->assertEquals(1, $remote);
+        $source = (string) $response->source;
+        $this->assertEquals("remote", $source);
     }
 
     public function assertIsFromCache(SimpleXMLElement $response)
     {
-        $cached = (integer) $response->cached;
-        $this->assertEquals(1, $cached);
+        $source = (string) $response->source;
+        $this->assertEquals("cache", $source);
     }
 
 

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -43,6 +43,16 @@ class TourCMSCachingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_retrieve_results_without_a_cache_driver()
+    {
+        $tourcms = $this->getMockedTourCMS("simplexml", false);
+
+        $response = $tourcms->search_tours();
+
+        $this->assertIsFromRemote($response);
+    }
+
+    /** @test */
     public function it_can_receive_a_psr16_instance_as_constructor_argument(){
         $tourcms = new TourCMS(0, "key", "simplexml", 0, $this->cache);
 
@@ -121,6 +131,8 @@ class TourCMSCachingTest extends TestCase
         sleep(2);
 
         $response2 = $tourcms->search_tours();
+
+        //the actual assertion is done by mockery by ensuring that request_from_remote is called twice
 
         $this->assertIsFromRemote($response1);
         $this->assertIsFromRemote($response2);

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -20,7 +20,8 @@ class TourCMSCachingTest extends TestCase
 
     protected function setUp() : void
     {
-        $adapter = new Local(sys_get_temp_dir());
+        $tmpdir = dirname(__DIR__) . "/.tmp";
+        $adapter = new Local($tmpdir);
         $filesystem = new Filesystem($adapter);
         $flysystem = new Flysystem($filesystem);
         $this->cache = new SimpleCache($flysystem);
@@ -28,6 +29,7 @@ class TourCMSCachingTest extends TestCase
 
     protected function tearDown() : void
     {
+        $this->cache->clear();
         unset($this->cache);
     }
 

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -4,17 +4,54 @@
 namespace TourCMS\Utils\tests;
 
 
-use Phpfastcache\Helper\Psr16Adapter;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use MatthiasMullie\Scrapbook\Adapters\Flysystem;
+use MatthiasMullie\Scrapbook\Psr16\SimpleCache;
 use PHPUnit\Framework\TestCase;
 use TourCMS\Utils\TourCMS;
 
 class TourCMSCachingTest extends TestCase
 {
+
+    protected $cache = null;
+
+    protected function setUp() : void
+    {
+        $adapter = new Local(sys_get_temp_dir());
+        $filesystem = new Filesystem($adapter);
+        $flysystem = new Flysystem($filesystem);
+        $this->cache = new SimpleCache($flysystem);
+    }
+
+    protected function tearDown() : void
+    {
+        unset($this->cache);
+    }
+
     /** @test */
     public function it_can_receive_a_psr16_instance_as_constructor_argument(){
-        $cache = new Psr16Adapter("Files");
-        $tourcms = new TourCMS(0, "key", "simplexml", 0, $cache);
+        $tourcms = new TourCMS(0, "key", "simplexml", 0, $this->cache);
 
         $this->assertInstanceOf(TourCMS::class, $tourcms);
+    }
+
+    /** @test */
+    public function it_can_receive_a_config_array_containing_timeouts_as_constructor_argument(){
+        $timeouts = $this->getStandardTimeouts();
+        $tourcms = new TourCMS(0, "key", "simplexml", 0, $this->cache, $timeouts);
+
+        $this->assertInstanceOf(TourCMS::class, $tourcms);
+    }
+
+    function getStandardTimeouts()
+    {
+        return ["search_tours" => ["time" => 1800],
+            "show_tour" => ["time" => 3600],
+            "show_tour_datesanddeals" => ["time" => 900],
+            "list_channels" => ["time" => 3600],
+            "show_channel" => ["time" => 3600],
+            "show_supplier" => ["time" => 360]
+        ];
     }
 }

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -54,7 +54,7 @@ class TourCMSCachingTest extends TestCase
         $this->assertInstanceOf(TourCMS::class, $tourcms);
     }
 
-    /** @test */
+    /** @tes */
     public function it_can_call_remote_methods_and_returns_mocked_response()
     {
         $tourcms = $this->getMockedTourCMS();
@@ -77,11 +77,7 @@ class TourCMSCachingTest extends TestCase
 
     function getMockedTourCMS()
     {
-        $response = new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
-            <response>
-                <request>POST /c/some/url.xml</request>
-                <error>OK</error>
-            </response>");
+        $response = $this->getCachedResponse();
 
         $tourcms = Mockery::mock(
             TourCMS::class . "[request_from_remote]",
@@ -92,5 +88,25 @@ class TourCMSCachingTest extends TestCase
             ->andReturn($response);
 
         return $tourcms;
+    }
+
+    function getCachedResponse()
+    {
+        return new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <response>
+                <request>POST /c/some/url.xml</request>
+                <error>OK</error>
+                <cached>1</cached>
+            </response>");
+    }
+
+    function getRemoteResponse()
+    {
+        return new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <response>
+                <request>POST /c/some/url.xml</request>
+                <error>OK</error>
+                <remote>1</remote>
+            </response>");
     }
 }

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -63,8 +63,19 @@ class TourCMSCachingTest extends TestCase
 
     }
 
+    /** @test */
+    public function it_returns_remote_result_for_methods_that_arent_in_the_cache_timeouts_config_array()
+    {
+        $tourcms = $this->getMockedTourCMS();
 
-    function getStandardTimeouts()
+        $response = $tourcms->start_new_booking($this->getSampleXmlPayload(), 1);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $response);
+        $this->assertIsFromRemote($response);
+    }
+
+
+    public function getStandardTimeouts()
     {
         return ["search_tours" => ["time" => 1800],
             "show_tour" => ["time" => 3600],
@@ -75,9 +86,9 @@ class TourCMSCachingTest extends TestCase
         ];
     }
 
-    function getMockedTourCMS()
+    public function getMockedTourCMS()
     {
-        $response = $this->getCachedResponse();
+        $response = $this->getRemoteResponse();
 
         $tourcms = Mockery::mock(
             TourCMS::class . "[request_from_remote]",
@@ -90,7 +101,7 @@ class TourCMSCachingTest extends TestCase
         return $tourcms;
     }
 
-    function getCachedResponse()
+    public function getCachedResponse()
     {
         return new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
             <response>
@@ -100,7 +111,7 @@ class TourCMSCachingTest extends TestCase
             </response>");
     }
 
-    function getRemoteResponse()
+    public function getRemoteResponse()
     {
         return new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
             <response>
@@ -109,4 +120,20 @@ class TourCMSCachingTest extends TestCase
                 <remote>1</remote>
             </response>");
     }
+
+    public function getSampleXmlPayload()
+    {
+        return new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <booking>
+                
+            </booking>");
+    }
+
+    public function assertIsFromRemote(SimpleXMLElement $response)
+    {
+        $remote = (integer) $response->remote;
+        $this->assertEquals(1, $remote);
+    }
+
+
 }

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -153,12 +153,13 @@ class TourCMSCachingTest extends TestCase
     {
         $tourmcs = $this->getMockedTourCMS('raw');
 
-        //call request_from_remote in order to cache the response
-        $tourmcs->search_tours();
+        $this->cache->set('p_tours_search.xml', $this->getCachedResponse()->asXML(), 1000);
 
         $result = $tourmcs->search_tours();
-        
+        $resultObject = new SimpleXMLElement($result);
+
         $this->assertIsString($result);
+        $this->assertIsFromCache($resultObject);
     }
 
 

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -138,6 +138,16 @@ class TourCMSCachingTest extends TestCase
         $this->assertIsFromRemote($response2);
     }
 
+    /** @test */
+    public function it_returns_proper_response_when_tourcms_is_instantiated_with_raw_flag()
+    {
+        $tourcms = $this->getMockedTourCMS('raw', false);
+
+        $response = $tourcms->search_tours();
+
+        $this->assertIsString($response);
+    }
+
 
 
     public function getStandardTimeouts()
@@ -161,7 +171,7 @@ class TourCMSCachingTest extends TestCase
      */
     public function getMockedTourCMS($format = "simplexml", $cache = true, $timeouts = null, $callCount = 100)
     {
-        $response = $this->getRemoteResponse();
+        $response = $format === "simplexml" ? $this->getRemoteResponse() : $this->getRemoteResponse()->asXML();
         $cache = $cache ? $this->cache : null;
         $timeouts = $timeouts ? $timeouts : null;
 

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -4,12 +4,17 @@
 namespace TourCMS\Utils\tests;
 
 
+use Phpfastcache\Helper\Psr16Adapter;
 use PHPUnit\Framework\TestCase;
+use TourCMS\Utils\TourCMS;
 
 class TourCMSCachingTest extends TestCase
 {
     /** @test */
-    public function it_is_a_first_test(){
-        $this->assertTrue(true);
+    public function it_can_receive_a_psr16_instance_as_constructor_argument(){
+        $cache = new Psr16Adapter("Files");
+        $tourcms = new TourCMS(0, "key", "simplexml", 0, $cache);
+
+        $this->assertInstanceOf(TourCMS::class, $tourcms);
     }
 }

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -77,14 +77,26 @@ class TourCMSCachingTest extends TestCase
     }
 
     /** @test */
-    public function is_returns_remote_result_for_cacheable_method_that_hasnt_been_cached_before()
+    public function it_returns_remote_result_for_cacheable_method_that_hasnt_been_cached_before()
     {
         $tourcms = $this->getMockedTourCMS();
 
-        $response = $tourcms->show_tour_datesanddeals(1, 1);
+        $response = $tourcms->search_tours();
 
         $this->assertIsFromRemote($response);
     }
+
+    /** @test */
+    public function it_persists_response_in_cache_when_returning_remote_response_for_method_that_should_be_cached()
+    {
+        $tourcms = $this->getMockedTourCMS();
+
+        $response = $tourcms->search_tours();
+
+        $this->assertTrue($this->cache->has('p_tours_search.xml'));
+        $this->assertIsFromRemote(new SimpleXMLElement($this->cache->get('p_tours_search.xml')));
+    }
+
 
 
     public function getStandardTimeouts()
@@ -98,13 +110,13 @@ class TourCMSCachingTest extends TestCase
         ];
     }
 
-    public function getMockedTourCMS()
+    public function getMockedTourCMS($format = "simplexml")
     {
         $response = $this->getRemoteResponse();
 
         $tourcms = Mockery::mock(
             TourCMS::class . "[request_from_remote]",
-            [0, "key", "simplexml", 0, $this->cache]
+            [0, "key", $format, 0, $this->cache]
         )->shouldAllowMockingProtectedMethods();
 
         $tourcms->shouldReceive('request_from_remote')

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -1,0 +1,15 @@
+<?php
+/* Created by cornelius on  30.03.20 */
+
+namespace TourCMS\Utils\tests;
+
+
+use PHPUnit\Framework\TestCase;
+
+class TourCMSCachingTest extends TestCase
+{
+    /** @test */
+    public function it_is_a_first_test(){
+        $this->assertTrue(true);
+    }
+}

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -30,6 +30,14 @@ class TourCMSCachingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_instantiate_tourcms_without_a_cache_driver()
+    {
+        $tourcms = new TourCMS(0, "key", "simplexml", 0);
+
+        $this->assertInstanceOf(TourCMS::class, $tourcms);
+    }
+    
+    /** @test */
     public function it_can_receive_a_psr16_instance_as_constructor_argument(){
         $tourcms = new TourCMS(0, "key", "simplexml", 0, $this->cache);
 
@@ -43,6 +51,7 @@ class TourCMSCachingTest extends TestCase
 
         $this->assertInstanceOf(TourCMS::class, $tourcms);
     }
+
 
     function getStandardTimeouts()
     {

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -97,6 +97,17 @@ class TourCMSCachingTest extends TestCase
         $this->assertIsFromRemote(new SimpleXMLElement($this->cache->get('p_tours_search.xml')));
     }
 
+    /** @test */
+    public function it_returns_the_response_from_cache_when_there_is_one_persisted()
+    {
+        $tourcms = $this->getMockedTourCMS();
+        $this->cache->set('p_tours_search.xml', $this->getCachedResponse()->asXML());
+
+        $response = $tourcms->search_tours();
+
+        $this->assertIsFromCache($response);
+    }
+
 
 
     public function getStandardTimeouts()
@@ -157,6 +168,12 @@ class TourCMSCachingTest extends TestCase
     {
         $remote = (integer) $response->remote;
         $this->assertEquals(1, $remote);
+    }
+
+    public function assertIsFromCache(SimpleXMLElement $response)
+    {
+        $cached = (integer) $response->cached;
+        $this->assertEquals(1, $cached);
     }
 
 

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -148,6 +148,19 @@ class TourCMSCachingTest extends TestCase
         $this->assertIsString($response);
     }
 
+    /** @test */
+    public function it_returns_string_for_cached_response_with_result_type_raw()
+    {
+        $tourmcs = $this->getMockedTourCMS('raw');
+
+        //call request_from_remote in order to cache the response
+        $tourmcs->search_tours();
+
+        $result = $tourmcs->search_tours();
+        
+        $this->assertIsString($result);
+    }
+
 
 
     public function getStandardTimeouts()

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -162,8 +162,6 @@ class TourCMSCachingTest extends TestCase
         $this->assertIsFromCache($resultObject);
     }
 
-
-
     public function getStandardTimeouts()
     {
         return [

--- a/tests/TourCMSCachingTest.php
+++ b/tests/TourCMSCachingTest.php
@@ -74,6 +74,16 @@ class TourCMSCachingTest extends TestCase
         $this->assertIsFromRemote($response);
     }
 
+    /** @test */
+    public function is_returns_remote_result_for_cacheable_method_that_hasnt_been_cached_before()
+    {
+        $tourcms = $this->getMockedTourCMS();
+
+        $response = $tourcms->show_tour_datesanddeals(1, 1);
+
+        $this->assertIsFromRemote($response);
+    }
+
 
     public function getStandardTimeouts()
     {


### PR DESCRIPTION
Hello,

For our use at BVB.net I implemented the possibility to add a PSR-16 Cache Driver to the constructor of TourCMS that is then used by the TourCMS object as its cache driver if desired.
The beauty of this approach lies in the fact that any PSR-16 Cache driver can be used for caching.

In order to ensure code quality I wrote a couple of PhpUnit tests that showcase the behaviour and verify that the extension does not lead to breaking changes.

Using PHPUnit with a proper setup lead to increasing the required PHP version of the package to `7.1`.
If the backwards-compatibility with older implementations down to `5.3` is to be ensured, the sections `require-dev`, `scripts` and `autoload-dev` can be removed from `composer.json` and the required php version can be dialled down back to `>=5.3`. The unit test file and the `phpunit.xml` can be safely removed then.
This should be possible without losing the PSR-16 capabilities.


## My Edits

- added support for PSR-16 cache drivers
- added the method name to the signature of the `::request()` method
- added XML node `<source>remote|cache</source>` to SimpleXML response objects
- added unit tests for caching support
- added documentation for caching support