### PR TITLE
Use mb_string for encoding string to UTF-8 in generate_signature().

### DIFF
--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -902,8 +902,9 @@ class TourCMS {
 	protected function generate_signature($path, $verb, $channel, $outbound_time) {
 
 		$string_to_sign = trim($channel."/".$this->marketp_id."/".$verb."/".$outbound_time.$path);
+		$string_to_sign = mb_convert_encoding($string_to_sign, "UTF-8", mb_detect_encoding($string_to_sign));
 
-		$signature = rawurlencode(base64_encode((hash_hmac("sha256", utf8_encode($string_to_sign), $this->private_key, TRUE ))));
+		$signature = rawurlencode(base64_encode((hash_hmac("sha256", $string_to_sign, $this->private_key, TRUE ))));
 
 		return $signature;
 	}


### PR DESCRIPTION
This fixes a deprecation warning in PHP 8.2 and above, fixes #91.