### PR TITLE
removes typed properties

### DIFF
--- a/src/TourCMS.php
+++ b/src/TourCMS.php
@@ -59,8 +59,8 @@ class TourCMS {
 	protected $last_response_headers = array();
 	protected $user_agent = "TourCMS PHP Wrapper v4.1.1";
 	protected $prepend_caller_to_user_agent = true;
-	protected array $headers = [];
-	protected array $permanent_headers = [];
+	protected $headers = [];
+	protected $permanent_headers = [];
 
 	/**
 	 * __construct


### PR DESCRIPTION
Removes typed properties from  `TourCms.php`.

Typed properties were introduced in [php 7.4](https://www.php.net/manual/en/language.oop5.properties.php), yet the package claims compatibility with php >=5.3. This PR fixes the compatibility issue.